### PR TITLE
Make ClientAuthenticator Sendable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ async = ["tokio", "tokio-tungstenite", "futures-util", "async-trait"]
 
 [dependencies]
 # base dependencies
-wampproto = { git = "https://github.com/xconnio/wampproto-rust.git", rev = "535b34522ecf030276ef4ce6be226cf2aefb9a9a" }
+wampproto = { git = "https://github.com/xconnio/wampproto-rust.git", rev = "520130fa02343409578879959748b36f151bbc8d" }
 tungstenite = {  version = "0.27.0", features = ["native-tls"] }
 url = { version = "2.5.4" }
 

--- a/src/async_/client.rs
+++ b/src/async_/client.rs
@@ -10,11 +10,11 @@ use wampproto::authenticators::wampcra::WAMPCRAAuthenticator;
 
 pub struct Client {
     serializer: Box<dyn SerializerSpec>,
-    authenticator: Box<dyn ClientAuthenticator>,
+    authenticator: Box<dyn ClientAuthenticator + Send + Sync>,
 }
 
 impl Client {
-    pub fn new(serializer: Box<dyn SerializerSpec>, authenticator: Box<dyn ClientAuthenticator>) -> Self {
+    pub fn new(serializer: Box<dyn SerializerSpec>, authenticator: Box<dyn ClientAuthenticator + Send + Sync>) -> Self {
         Self {
             serializer,
             authenticator,

--- a/src/async_/joiner.rs
+++ b/src/async_/joiner.rs
@@ -13,7 +13,7 @@ use wampproto::serializers::serializer::Serializer;
 
 pub struct WebSocketJoiner {
     serializer: Box<dyn SerializerSpec>,
-    authenticator: Box<dyn ClientAuthenticator>,
+    authenticator: Box<dyn ClientAuthenticator + Send + Sync>,
 }
 
 impl Default for WebSocketJoiner {
@@ -26,7 +26,7 @@ impl Default for WebSocketJoiner {
 }
 
 impl WebSocketJoiner {
-    pub fn new(serializer: Box<dyn SerializerSpec>, authenticator: Box<dyn ClientAuthenticator>) -> Self {
+    pub fn new(serializer: Box<dyn SerializerSpec>, authenticator: Box<dyn ClientAuthenticator + Send + Sync>) -> Self {
         Self {
             serializer,
             authenticator,
@@ -52,7 +52,7 @@ pub async fn join(
     peer: Box<dyn Peer>,
     realm: &str,
     serializer: Box<dyn Serializer>,
-    authenticator: Box<dyn ClientAuthenticator>,
+    authenticator: Box<dyn ClientAuthenticator + Send + Sync>,
 ) -> Result<(Box<dyn Peer>, SessionDetails), Error> {
     let mut proto = joiner::Joiner::new(realm, serializer.clone(), authenticator);
 
@@ -89,7 +89,7 @@ pub async fn join(
 
 pub struct RawSocketJoiner {
     serializer: Box<dyn SerializerSpec>,
-    authenticator: Box<dyn ClientAuthenticator>,
+    authenticator: Box<dyn ClientAuthenticator + Send + Sync>,
 }
 
 impl Default for RawSocketJoiner {
@@ -102,7 +102,7 @@ impl Default for RawSocketJoiner {
 }
 
 impl RawSocketJoiner {
-    pub fn new(serializer: Box<dyn SerializerSpec>, authenticator: Box<dyn ClientAuthenticator>) -> Self {
+    pub fn new(serializer: Box<dyn SerializerSpec>, authenticator: Box<dyn ClientAuthenticator + Send + Sync>) -> Self {
         Self {
             serializer,
             authenticator,

--- a/src/sync/client.rs
+++ b/src/sync/client.rs
@@ -10,11 +10,11 @@ use wampproto::authenticators::wampcra::WAMPCRAAuthenticator;
 
 pub struct Client {
     serializer: Box<dyn SerializerSpec>,
-    authenticator: Box<dyn ClientAuthenticator>,
+    authenticator: Box<dyn ClientAuthenticator + Send + Sync>,
 }
 
 impl Client {
-    pub fn new(serializer: Box<dyn SerializerSpec>, authenticator: Box<dyn ClientAuthenticator>) -> Self {
+    pub fn new(serializer: Box<dyn SerializerSpec>, authenticator: Box<dyn ClientAuthenticator + Send + Sync>) -> Self {
         Self {
             serializer,
             authenticator,

--- a/src/sync/joiner.rs
+++ b/src/sync/joiner.rs
@@ -12,7 +12,7 @@ use wampproto::serializers::serializer::Serializer;
 
 pub struct WebSocketJoiner {
     serializer: Box<dyn SerializerSpec>,
-    authenticator: Box<dyn ClientAuthenticator>,
+    authenticator: Box<dyn ClientAuthenticator + Send + Sync>,
 }
 
 impl Default for WebSocketJoiner {
@@ -72,7 +72,7 @@ fn connect_and_upgrade(addr: &str, subprotocol: &str) -> Result<TcpStream, Error
 }
 
 impl WebSocketJoiner {
-    pub fn new(serializer: Box<dyn SerializerSpec>, authenticator: Box<dyn ClientAuthenticator>) -> Self {
+    pub fn new(serializer: Box<dyn SerializerSpec>, authenticator: Box<dyn ClientAuthenticator + Send + Sync>) -> Self {
         Self {
             serializer,
             authenticator,
@@ -91,7 +91,7 @@ pub fn join(
     peer: Box<dyn Peer>,
     realm: &str,
     serializer: Box<dyn Serializer>,
-    authenticator: Box<dyn ClientAuthenticator>,
+    authenticator: Box<dyn ClientAuthenticator + Send + Sync>,
 ) -> Result<(Box<dyn Peer>, SessionDetails), Error> {
     let mut proto = joiner::Joiner::new(realm, serializer.clone(), authenticator);
 


### PR DESCRIPTION
This change will let us use ClientAuthenticator in multi-threaded apps.